### PR TITLE
report the result when setting jail atributes

### DIFF
--- a/iocage
+++ b/iocage
@@ -576,6 +576,7 @@ def main():
 
     elif p["state"] == "set":
         changed, _msg = jail_set(module, iocage_path, name, properties)
+        msgs.append(_msg)
         jails[name] = _get_iocage_facts(module,iocage_path,"jails",name)
 
     elif p["state"] in ["present", "cloned", "template", "basejail"]:


### PR DESCRIPTION
While setting properties of jails works, it's never reported back to the user.