### PR TITLE
Add option to only use some components when unpacking a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ fetch host's RELEASE:
 ```
 iocage: state=fetched
 ```
+
+fetch just the base component of host's RELEASE:
+```
+iocage: state=fetched components=base.txz
+```
+
+fetch host's RELEASE, limited to base and doc components:
+```
+iocage: state=fetched components=base.txz,doc.txz
+```
+
 create basejail:
 ```
 iocage: state=basejail name="foo" release=11.0-RELEASE

--- a/iocage
+++ b/iocage
@@ -202,10 +202,12 @@ def _props_to_str(props):
 
     return argstr
 
-def release_fetch(module, iocage_path, update=False, release="NO-RELEASE", args=""):
+def release_fetch(module, iocage_path, update=False, release="NO-RELEASE", components="", args=""):
     if not module.check_mode:
         if update:
             args += " -U"
+        for _component in components:
+            args += " -F {}".format(_component)
         cmd = "{0} fetch -r {1} {2}".format(iocage_path, release, args)
         rc = 1
         rc, out, err = module.run_command(cmd)
@@ -312,6 +314,7 @@ def _jail_get_properties(module, iocage_path, name):
     return properties
 
 def jail_set(module, iocage_path, name, properties={}):
+
     _changed = False
     rc = 1
     out = ""
@@ -358,6 +361,7 @@ def jail_set(module, iocage_path, name, properties={}):
                 module.fail_json(msg="Attributes could not be set on jail '{0}'.\ncmd:\n{1}\nstdout:\n{2}\nstderr:\n{3}".format(name, cmd, out, err))
 
             _msg = "properties {0} were set on jail '{1}' with cmd={2}.".format(str(_props_to_be_changed.keys()) ,name, cmd)
+
 
         else:
             _msg = "properties {0} would have been changed for jail {1} with command {2}".format(str(_props_to_be_changed.keys()), name, cmd)
@@ -460,7 +464,8 @@ def main():
             cmd          = dict(default="", required=False),
             clone_from   = dict(default="", required=False),
             release      = dict(default="", required=False),
-            update       = dict(default="", required=False)),
+            update       = dict(default="", required=False),
+            components   = dict(default="", aliases=["files","component"], required=False, type='list')),
         supports_check_mode = True
     )
 
@@ -477,6 +482,7 @@ def main():
     user = p["user"] or "root"
     release = p["release"]
     update = p["update"]
+    components = p["components"]
     upgrade = False
 
     if not release or release == "":
@@ -566,7 +572,7 @@ def main():
 
     elif p["state"] == "fetched":
         if update or release not in facts["iocage_releases"]:
-            rel, changed, _msg = release_fetch(module, iocage_path, update, release, args)
+            rel, changed, _msg = release_fetch(module, iocage_path, update, release, components, args)
             msgs.append(_msg)
             facts["iocage_releases"] = _get_iocage_facts(module,iocage_path,"releases")
             if release not in facts["iocage_releases"] or update:
@@ -586,7 +592,7 @@ def main():
         jail_exists = False
 
         if not release in facts["iocage_releases"]:
-            release, _release_changed, _release_msg = release_fetch(module,iocage_path,update,release)
+            release, _release_changed, _release_msg = release_fetch(module,iocage_path,update,release, components, args)
             if _release_changed:
                 facts["iocage_releases"] = _get_iocage_facts(module,iocage_path,"releases")
                 msgs.append(_release_msg)
@@ -622,7 +628,7 @@ def main():
 
         if p["update"]:
             if not release in facts["iocage_releases"]:
-                release, _release_changed, _release_msg = release_fetch(module,iocage_path,update,release)
+                release, _release_changed, _release_msg = release_fetch(module,iocage_path,update,release, components, args)
                 if _release_changed:
                     _msg += _release_msg
                     facts["iocage_releases"] = _get_iocage_facts(module,iocage_path,"releases")


### PR DESCRIPTION
While most users think, (disk)space is no longer a problem, I still like to keep my jails lean.
This patch enables one to just download/unpack the components you really want.